### PR TITLE
Upgrade jinja2 to get rid of security alert

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ click==6.7
 Flask==0.12.2
 Flask-SQLAlchemy==2.3.2
 itsdangerous==0.24
-Jinja2==2.9.6
+Jinja2==2.10.1
 MarkupSafe==1.0
 psycopg2==2.7.3.2
 SQLAlchemy==1.1.15


### PR DESCRIPTION
@calellowitz @snopoke I think this is used in the devops final round right? I think this should be safe though admittedly didn't test it

https://github.com/pallets/jinja/blob/master/CHANGES.rst#version-2101